### PR TITLE
Move datum implicits to a package higher

### DIFF
--- a/engine/src/main/scala/org/scalarules/dsl/nl/datum/DatumImplicits.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/datum/DatumImplicits.scala
@@ -1,4 +1,4 @@
-package org.scalarules.dsl.nl.grammar.datum
+package org.scalarules.dsl.nl.datum
 
 import java.util.Date
 

--- a/engine/src/main/scala/org/scalarules/dsl/nl/datum/package.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/datum/package.scala
@@ -1,0 +1,5 @@
+package org.scalarules.dsl.nl
+
+package object datum extends DatumImplicits {
+
+}

--- a/engine/src/main/scala/org/scalarules/dsl/nl/grammar/package.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/grammar/package.scala
@@ -1,6 +1,6 @@
 package org.scalarules.dsl.nl
 
-import org.scalarules.dsl.nl.grammar.datum.DatumImplicits
+import org.scalarules.dsl.nl.datum.DatumImplicits
 import org.scalarules.engine._
 
 package object grammar extends DslConditionImplicits

--- a/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumImplicitsTest.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumImplicitsTest.scala
@@ -1,4 +1,4 @@
-package org.scalarules.dsl.nl.grammar.datum
+package org.scalarules.dsl.nl.datum
 
 import org.scalarules.dsl.nl.finance.{Bedrag, Percentage}
 import org.scalarules.engine.{Context, FactEngine, SingularFact}

--- a/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumTest.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumTest.scala
@@ -1,9 +1,9 @@
-package org.scalarules.dsl.nl.grammar.datum
+package org.scalarules.dsl.nl.datum
 
 import org.joda.time.LocalDate
 import org.scalarules.dsl.nl.grammar.aanwezig
 import org.scalarules.utils.InternalBerekeningenTester
-import org.scalarules.dsl.nl.grammar.datum.DatumTestGlossary._
+import org.scalarules.dsl.nl.datum.DatumTestGlossary._
 
 class DatumTest extends InternalBerekeningenTester(new DatumTestsBerekening) with DatumImplicits {
 

--- a/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumTestGlossary.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumTestGlossary.scala
@@ -1,6 +1,5 @@
-package org.scalarules.dsl.nl.grammar.datum
+package org.scalarules.dsl.nl.datum
 
-import org.scalarules.dsl.nl.grammar._
 import org.scalarules.engine.SingularFact
 import org.scalarules.utils.Glossary
 

--- a/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumTestsBerekening.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/datum/DatumTestsBerekening.scala
@@ -1,7 +1,7 @@
-package org.scalarules.dsl.nl.grammar.datum
+package org.scalarules.dsl.nl.datum
 
 import org.scalarules.dsl.nl.grammar._
-import org.scalarules.dsl.nl.grammar.datum.DatumTestGlossary._
+import org.scalarules.dsl.nl.datum.DatumTestGlossary._
 
 class DatumTestsBerekening extends Berekening (
 


### PR DESCRIPTION
since it is not part of the grammar per se. Also added its own package object, so it can be imported. Importing org.scalarules.dsl.nl.grammar._ in a BerekeningTest will not work properly with the 'is' implicit of the TestDsl. This package move makes it more clear that you can (and should) import the DatumImplicits on its own.
