### PR TITLE
Adding DSL traits to aggregate implicits so users of scala-rules can …

### DIFF
--- a/engine/src/main/scala/org/scalarules/dsl/nl/ScalaRulesDsl.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/ScalaRulesDsl.scala
@@ -1,0 +1,16 @@
+package org.scalarules.dsl.nl
+
+import org.scalarules.dsl.nl.datum.DatumImplicits
+import org.scalarules.dsl.nl.grammar.{DslCondition, DslConditionImplicits, DslEvaluationImplicits, GegevenWord}
+import org.scalarules.engine._
+
+trait ScalaRulesDsl extends DslConditionImplicits
+  with DslEvaluationImplicits
+  with DatumImplicits {
+
+  type ConditionFunction = (Condition, Condition) => Condition
+
+  // Entrypoint for the DSL
+  def Gegeven(condition: DslCondition): GegevenWord = new GegevenWord(condition) //scalastyle:ignore method.name
+
+}

--- a/engine/src/main/scala/org/scalarules/dsl/nl/ScalaRulesDsl.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/ScalaRulesDsl.scala
@@ -4,6 +4,10 @@ import org.scalarules.dsl.nl.datum.DatumImplicits
 import org.scalarules.dsl.nl.grammar.{DslCondition, DslConditionImplicits, DslEvaluationImplicits, GegevenWord}
 import org.scalarules.engine._
 
+/**
+  * Aggregates the keywords and implicit definitions of the Scala-Rules DSL. The implicits available in this
+  * trait can be used by importing the `grammar` package object's members, or extending this trait.
+  */
 trait ScalaRulesDsl extends DslConditionImplicits
   with DslEvaluationImplicits
   with DatumImplicits {

--- a/engine/src/main/scala/org/scalarules/dsl/nl/finance/FinanceDsl.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/finance/FinanceDsl.scala
@@ -1,0 +1,24 @@
+package org.scalarules.dsl.nl.finance
+
+/**
+  * Aggregeert de implicits van de verschillende onderdelen van de DSL. Op deze manier is een simpel
+  *     import nl.rabobank.itn.fpx.moa.calculation.dsl._
+  * genoeg om alle implicits van de DSL in scope te brengen.
+  */
+trait FinanceDsl extends BedragImplicits
+  with PeriodeImplicits
+  with PercentageImplicits
+  with PerImplicits
+  with Ordering.ExtraImplicits {
+
+  type Looptijd = Periode
+
+  /** Singleton Termijn-instantie van 1 maand. */
+  val Maand = Termijn.Maand
+  /** Singleton Termijn-instantie van 3 maanden. */
+  val Kwartaal = Termijn.Kwartaal
+  /** Singleton Termijn-instantie van 6 maanden. */
+  val Halfjaar = Termijn.Halfjaar
+  /** Singleton Termijn-instantie van 12 maanden / 1 jaar. */
+  val Jaar = Termijn.Jaar
+}

--- a/engine/src/main/scala/org/scalarules/dsl/nl/finance/package.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/finance/package.scala
@@ -5,20 +5,6 @@ package org.scalarules.dsl.nl
   *     import nl.rabobank.itn.fpx.moa.calculation.dsl._
   * genoeg om alle implicits van de DSL in scope te brengen.
   */
-package object finance extends BedragImplicits
-    with PeriodeImplicits
-    with PercentageImplicits
-    with PerImplicits
-    with Ordering.ExtraImplicits {
+package object finance extends FinanceDsl {
 
-  type Looptijd = Periode
-
-  /** Singleton Termijn-instantie van 1 maand. */
-  val Maand = Termijn.Maand
-  /** Singleton Termijn-instantie van 3 maanden. */
-  val Kwartaal = Termijn.Kwartaal
-  /** Singleton Termijn-instantie van 6 maanden. */
-  val Halfjaar = Termijn.Halfjaar
-  /** Singleton Termijn-instantie van 12 maanden / 1 jaar. */
-  val Jaar = Termijn.Jaar
 }

--- a/engine/src/main/scala/org/scalarules/dsl/nl/grammar/package.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/grammar/package.scala
@@ -1,15 +1,5 @@
 package org.scalarules.dsl.nl
 
-import org.scalarules.dsl.nl.datum.DatumImplicits
-import org.scalarules.engine._
-
-package object grammar extends DslConditionImplicits
-    with DslEvaluationImplicits
-    with DatumImplicits {
-
-  type ConditionFunction = (Condition, Condition) => Condition
-
-  // Entrypoint for the DSL
-  def Gegeven(condition: DslCondition): GegevenWord = new GegevenWord(condition) //scalastyle:ignore method.name
+package object grammar extends ScalaRulesDsl {
 
 }

--- a/engine/src/main/scala/org/scalarules/dsl/nl/grammar/package.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/grammar/package.scala
@@ -1,5 +1,9 @@
 package org.scalarules.dsl.nl
 
+/**
+  * Aggregates the keywords and implicit definitions of the Scala-Rules DSL. Import this package's members to
+  * use the DSL in your files.
+  */
 package object grammar extends ScalaRulesDsl {
 
 }


### PR DESCRIPTION
…extend the DSL more easily.

Until now, you could only import `org.scalarules.dsl.nl.grammar._` to enable the DSL. Now, if you want to extend the DSL, you can create your own package object and extend `org.scalarules.dsl.nl.ScalaRulesDsl`
