### PR TITLE
Release/v0.2.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.8-SNAPSHOT",
+  version := "0.2.8",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.8",
+  version := "0.2.9SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.7-SNAPSHOT",
+  version := "0.2.7",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.7",
+  version := "0.2.8-SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/engine-core/src/main/scala/org/scalarules/engine/facts.scala
+++ b/engine-core/src/main/scala/org/scalarules/engine/facts.scala
@@ -1,8 +1,6 @@
 package org.scalarules.engine
 
-import scala.annotation.tailrec
 import scala.language.existentials
-import scala.reflect.runtime.universe._
 
 trait Fact[+A] {
   def name: String
@@ -12,13 +10,13 @@ trait Fact[+A] {
   def toEval: Evaluation[A]
 }
 
-case class SingularFact[+A : TypeTag](name: String, isResult: Boolean = true, description: String = "") extends Fact[A] {
+case class SingularFact[+A](name: String, isResult: Boolean = true, description: String = "") extends Fact[A] {
   def toEval: Evaluation[A] = new SingularFactEvaluation(this)
 
   override def toString: String = name
 }
 
-case class ListFact[+A : TypeTag](name: String, isResult: Boolean = true, description: String = "") extends Fact[List[A]] {
+case class ListFact[+A](name: String, isResult: Boolean = true, description: String = "") extends Fact[List[A]] {
   def toEval: Evaluation[List[A]] = new ListFactEvaluation[A](this)
 
   override def toString: String = name

--- a/engine/src/main/scala/org/scalarules/dsl/core/glossaries/Glossary.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/core/glossaries/Glossary.scala
@@ -17,13 +17,13 @@ class Glossary {
     facts += (name -> newFact)
   }
 
-  def defineFact[A: TypeTag](naam: String, omschrijving: String = "Geen beschrijving"): SingularFact[A] = {
+  def defineFact[A](naam: String, omschrijving: String = "Geen beschrijving"): SingularFact[A] = {
     val newFact = new SingularFact[A](naam, false, omschrijving)
     addAndCheckFacts( newFact )
     newFact
   }
 
-  def defineListFact[A: TypeTag](naam: String, omschrijving: String = "Geen beschrijving"): ListFact[A] = {
+  def defineListFact[A](naam: String, omschrijving: String = "Geen beschrijving"): ListFact[A] = {
     val newFact = new ListFact[A](naam, true, omschrijving)
     addAndCheckFacts( newFact )
     newFact


### PR DESCRIPTION
The `TypeTag` was still part of the `Fact` types. This still caused Scala to initialise the reflection API.

This release removes type tags completely.
