### PR TITLE
Release/v0.2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.10",
+  version := "0.2.11-SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.11-SNAPSHOT",
+  version := "0.2.11",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.11",
+  version := "0.2.12-SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Seq(
   organization := "org.scala-rules",
   organizationHomepage := Some(url("https://github.com/scala-rules/scala-rules")),
   homepage := Some(url("https://github.com/scala-rules/scala-rules")),
-  version := "0.2.10-SNAPSHOT",
+  version := "0.2.10",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint", "-Xfatal-warnings")
 ) ++ staticAnalysisSettings ++ publishSettings

--- a/engine-core/src/main/scala/org/scalarules/engine/FactEngine.scala
+++ b/engine-core/src/main/scala/org/scalarules/engine/FactEngine.scala
@@ -1,12 +1,13 @@
 package org.scalarules.engine
 
+import org.scalarules.engine.DerivationTools._
+
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
-import org.scalarules.engine.DerivationTools._
 
 object FactEngine {
 
-  var graphCache: Map[List[Derivation], Levels] = Map()
+  private var graphCache = new LRUCache[List[Derivation], Levels]()
 
   /**
     * Constructs a Dependency graph for the provided list of Derivations. Each Derivation will yield a Node describing its output and other Nodes requiring its
@@ -93,8 +94,8 @@ object FactEngine {
     * @return the resulting state of the last invocation to the evaluator function.
     */
   def runDerivations[A](state: A, derivations: List[Derivation], evaluator: (A, Derivation) => A): A = {
-    if (!graphCache.contains(derivations)) {
-      graphCache += derivations -> FactEngine.levelSorter(FactEngine.constructGraph(derivations))
+    if (!graphCache.get(derivations).isDefined) {
+      graphCache.add(derivations, FactEngine.levelSorter(FactEngine.constructGraph(derivations)))
     }
 
     val graph: Levels = graphCache.get(derivations).get

--- a/engine-core/src/main/scala/org/scalarules/engine/LRUCache.scala
+++ b/engine-core/src/main/scala/org/scalarules/engine/LRUCache.scala
@@ -1,0 +1,43 @@
+package org.scalarules.engine
+
+import scala.collection.concurrent.TrieMap
+
+class LRUCache[K, V](val maxSize: Int = LRUCache.GRAPH_CACHE_MAX_SIZE, val cleanupInterval: Long = LRUCache.GRAPH_CACHE_CLEANUP_INTERVAL_MS) {
+
+  private var graphCache: TrieMap[K, (V, Long)] = TrieMap()
+  private var lastCacheCleanup = System.currentTimeMillis()
+
+  def add(key: K, value: V): V = {
+    updateCacheWithNewEntry(key, value)
+    value
+  }
+
+  def get(key: K): Option[V] = graphCache.get(key).map{ case (cacheEntry, timestamp) => cacheEntry }
+
+  def size: Int = graphCache.size
+
+  private def updateCacheWithNewEntry(key: K, value: V): Unit = {
+    if ((System.currentTimeMillis() - lastCacheCleanup) > maxSize) {
+      // Cleaning up the cache before adding anything new to it
+      val cacheEntriesSortedByAge: List[(K, (V, Long))] = graphCache.toList.sortBy[Long]( entry => entry._2._2 )
+      val removalCandidates =
+        if (cacheEntriesSortedByAge.size > maxSize)
+          cacheEntriesSortedByAge.takeRight(cacheEntriesSortedByAge.size - maxSize)
+        else
+          List()
+
+      removalCandidates.map{ case (key, value) => graphCache -= key }
+
+      lastCacheCleanup = System.currentTimeMillis()
+    }
+
+    graphCache += key -> ((value, System.currentTimeMillis()))
+  }
+
+
+}
+
+object LRUCache {
+  val GRAPH_CACHE_MAX_SIZE: Int = 15
+  val GRAPH_CACHE_CLEANUP_INTERVAL_MS: Long = 5000
+}

--- a/engine-core/src/main/scala/org/scalarules/engine/LRUCache.scala
+++ b/engine-core/src/main/scala/org/scalarules/engine/LRUCache.scala
@@ -38,6 +38,6 @@ class LRUCache[K, V](val maxSize: Int = LRUCache.GRAPH_CACHE_MAX_SIZE, val clean
 }
 
 object LRUCache {
-  val GRAPH_CACHE_MAX_SIZE: Int = 15
+  val GRAPH_CACHE_MAX_SIZE: Int = 100
   val GRAPH_CACHE_CLEANUP_INTERVAL_MS: Long = 5000
 }

--- a/engine-core/src/test/scala/org/scalarules/engine/LRUCacheTest.scala
+++ b/engine-core/src/test/scala/org/scalarules/engine/LRUCacheTest.scala
@@ -1,0 +1,20 @@
+package org.scalarules.engine
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class LRUCacheTest extends FlatSpec with Matchers {
+
+  it should "cleanup older items back to initial size" in {
+    val cache: LRUCache[Int, Int] = new LRUCache(4, 10)
+
+    (0 until 10).foreach( (n: Int) => cache.add(n, n) )
+
+    Thread.sleep(20)
+
+    cache.add(15, 15)
+
+    cache.size should be (5)
+    cache.get(15) should be(Some(15))
+  }
+
+}


### PR DESCRIPTION
Initially intended to re-integrate the naive Graph cache. During CI tests, the naive version appeared to be too naive. Replaced it with a concurrent LRUCache.

Might still want to consider using someone else's LRUCache implementation, but it will suffice for now.
