### PR TITLE
Added implicit conversion from BigDecimal to Afrondbaar[BigDecimal]. …

### DIFF
--- a/engine/src/main/scala/org/scalarules/dsl/nl/grammar/AfrondingsWords.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/grammar/AfrondingsWords.scala
@@ -110,6 +110,13 @@ trait Afrondbaar[T] {
 }
 
 trait AfrondingsImplicits {
+  implicit def afrondbaarBigDecimal: Afrondbaar[BigDecimal] = {
+    new Afrondbaar[BigDecimal] {
+      override def rondAfOp(afTeRonden: BigDecimal, aantalDecimalen: Integer, afrondingsWijze: RoundingMode): BigDecimal =
+      afTeRonden.setScale(aantalDecimalen, afrondingsWijze)
+    }
+  }
+
   implicit def afrondbaarPercentage: Afrondbaar[Percentage] = {
     new Afrondbaar[Percentage] {
       override def rondAfOp(afTeRonden: Percentage, aantalDecimalen: Integer, afrondingsWijze: RoundingMode): Percentage =

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsTestBerekening.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsTestBerekening.scala
@@ -7,6 +7,37 @@ import scala.language.postfixOps
 
 class AfrondingsTestBerekening extends Berekening (
 
+  /* BigDecimal test calculations*/
+  Gegeven(afrondingsType is "halfNaarEven") Bereken
+    afgerondBigDecimalHalfEven is (startBigDecimal halfNaarEven afgerond op 0 decimalen)
+  ,
+
+  Gegeven(afrondingsType is "halfNaarNulToe") Bereken
+    afgerondBigDecimalHalfNaarNulToe is (startBigDecimal halfNaarNulToe afgerond op 0 decimalen)
+  ,
+
+  Gegeven(afrondingsType is "naarBeneden") Bereken
+    afgerondBigDecimalNaarBeneden is (startBigDecimal naarBeneden afgerond op 0 decimalen)
+  ,
+
+  Gegeven(afrondingsType is "naarBoven") Bereken
+    afgerondBigDecimalNaarBoven is (startBigDecimal naarBoven afgerond op 0 decimalen)
+  ,
+
+  Gegeven(afrondingsType is "naarNulToe") Bereken
+    afgerondBigDecimalNaarNulToe is (startBigDecimal naarNulToe afgerond op 0 decimalen)
+  ,
+
+  Gegeven(afrondingsType is "rekenkundig") Bereken
+    afgerondBigDecimalRekenkundig is (startBigDecimal rekenkundig afgerond op 0 decimalen)
+  ,
+
+  Gegeven(afrondingsType is "vanNulAf") Bereken
+    afgerondBigDecimalVanNulAf is (startBigDecimal vanNulAf afgerond op 0 decimalen)
+  ,
+
+
+  /* Percentage test calculations*/
   Gegeven(afrondingsType is "halfNaarEven") Bereken
     afgerondPercentageHalfEven is (startPercentage halfNaarEven afgerond op 0 decimalen)
   ,
@@ -35,6 +66,8 @@ class AfrondingsTestBerekening extends Berekening (
     afgerondPercentageVanNulAf is (startPercentage vanNulAf afgerond op 0 decimalen)
   ,
 
+
+  /* Bedrag test calculations*/
   Gegeven(afrondingsType is "halfNaarEven") Bereken
     afgerondBedragHalfEven is (startBedrag halfNaarEven afgerond op 0 decimalen)
   ,

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsTestBerekeningGlossary.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsTestBerekeningGlossary.scala
@@ -5,7 +5,17 @@ import org.scalarules.utils.Glossary
 
 object AfrondingsTestBerekeningGlossary extends Glossary {
 
-  val aantal = defineFact[Integer]()
+  val afrondingsType = defineFact[String]()
+
+  val startBigDecimal = defineFact[BigDecimal]()
+  val afgerondBigDecimalHalfEven = defineFact[BigDecimal]()
+  val afgerondBigDecimalHalfNaarNulToe = defineFact[BigDecimal]()
+  val afgerondBigDecimalNaarBeneden = defineFact[BigDecimal]()
+  val afgerondBigDecimalNaarBoven = defineFact[BigDecimal]()
+  val afgerondBigDecimalNaarNulToe = defineFact[BigDecimal]()
+  val afgerondBigDecimalRekenkundig = defineFact[BigDecimal]()
+  val afgerondBigDecimalVanNulAf = defineFact[BigDecimal]()
+  
   val startPercentage = defineFact[Percentage]()
   val afgerondPercentageHalfEven = defineFact[Percentage]()
   val afgerondPercentageHalfNaarNulToe = defineFact[Percentage]()
@@ -23,6 +33,5 @@ object AfrondingsTestBerekeningGlossary extends Glossary {
   val afgerondBedragNaarNulToe = defineFact[Bedrag]()
   val afgerondBedragRekenkundig = defineFact[Bedrag]()
   val afgerondBedragVanNulAf = defineFact[Bedrag]()
-  val afrondingsType = defineFact[String]()
 
 }

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsWordsTest.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsWordsTest.scala
@@ -11,8 +11,226 @@ import org.scalatest.prop.Checkers
 
 import scala.language.postfixOps
 
+/**
+  * There is a fair bit of duplication going on here, however, rounding issues can be very subtle yet quite destructive.
+  * This way there is a fair bit of redundancy within the tests and a lot of numbers are run through the functions so
+  * if any discrepancies exist between the DSL and the corresponding BigDecimal.setScale function, we will find them.
+  */
 class AfrondingsWordsTest extends PropSpec with Checkers {
 
+  /* BigDecimal property base tests*/
+  property("BigDecimal: halfNaarEven should match BigDecimal.RoundingMode.HALF_EVEN for positive doubles") {
+    check(
+      forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "halfNaarEven")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalHalfEven)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.HALF_EVEN) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: halfNaarEven should match BigDecimal.RoundingMode.HALF_EVEN for negative doubles") {
+    check(
+      forAll (for {testGetal <- Gen.negNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "halfNaarEven")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalHalfEven)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.HALF_EVEN) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: halfNaarNulToe should match BigDecimal.RoundingMode.HALF_DOWN for positive doubles") {
+    check(
+      forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "halfNaarNulToe")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalHalfNaarNulToe)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.HALF_DOWN) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: halfNaarNulToe should match BigDecimal.RoundingMode.HALF_DOWN for negative doubles") {
+    check(
+      forAll (for {testGetal <- Gen.negNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "halfNaarNulToe")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalHalfNaarNulToe)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.HALF_DOWN) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: naarBeneden should match BigDecimal.RoundingMode.FLOOR for positive doubles") {
+    check(
+      forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "naarBeneden")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalNaarBeneden)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.FLOOR) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: naarBeneden should match BigDecimal.RoundingMode.FLOOR for negative doubles") {
+    check(
+      forAll (for {testGetal <- Gen.negNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "naarBeneden")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalNaarBeneden)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.FLOOR) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: naarBoven should match BigDecimal.RoundingMode.CEILING for positive doubles") {
+    check(
+      forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "naarBoven")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalNaarBoven)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.CEILING) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: naarBoven should match BigDecimal.RoundingMode.CEILING for negative doubles") {
+    check(
+      forAll (for {testGetal <- Gen.negNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "naarBoven")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalNaarBoven)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.CEILING) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: naarNulToe should match BigDecimal.RoundingMode.DOWN for positive doubles") {
+    check(
+      forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "naarNulToe")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalNaarNulToe)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.DOWN) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: naarNulToe should match BigDecimal.RoundingMode.DOWN for negative doubles") {
+    check(
+      forAll (for {testGetal <- Gen.negNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "naarNulToe")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalNaarNulToe)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.DOWN) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: rekenkundig should match BigDecimal.RoundingMode.HALF_UP for positive doubles") {
+    check(
+      forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "rekenkundig")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalRekenkundig)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.HALF_UP) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: rekenkundig should match BigDecimal.RoundingMode.HALF_UP for negative doubles") {
+    check(
+      forAll (for {testGetal <- Gen.negNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "rekenkundig")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalRekenkundig)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.HALF_UP) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: vanNulAf should match BigDecimal.RoundingMode.UP for positive doubles") {
+    check(
+      forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "vanNulAf")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalVanNulAf)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.UP) )
+
+      }
+    )
+  }
+
+  property("BigDecimal: vanNulAf should match BigDecimal.RoundingMode.UP for negative doubles") {
+    check(
+      forAll (for {testGetal <- Gen.negNum[Double]} yield testGetal) { testGetal: Double =>
+
+        val context: Context = Map(startBigDecimal -> BigDecimal(testGetal),
+                                    afrondingsType -> "vanNulAf")
+
+        val uitkomst: Option[BigDecimal] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBigDecimalVanNulAf)
+
+        all(uitkomst.isDefined, uitkomst.get == BigDecimal(testGetal).setScale(0, BigDecimal.RoundingMode.UP) )
+
+      }
+    )
+  }
+
+
+  /* Percentage property based test*/
   property("Percentage: halfNaarEven should match BigDecimal.RoundingMode.HALF_EVEN for positive doubles") {
     check(
       forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
@@ -223,12 +441,13 @@ class AfrondingsWordsTest extends PropSpec with Checkers {
     )
   }
 
+  /* Bedrag property based tests*/
   property("Bedrag: halfNaarEven should match BigDecimal.RoundingMode.HALF_EVEN for positive doubles") {
     check(
       forAll (for {testGetal <- Gen.posNum[Double]} yield testGetal) { testGetal: Double =>
 
         val context: Context = Map(startBedrag -> BigDecimal(testGetal).euro,
-                                    afrondingsType -> "halfNaarEven")
+          afrondingsType -> "halfNaarEven")
 
         val uitkomst: Option[Bedrag] = runAndExtractFact(context, new AfrondingsTestBerekening().berekeningen, afgerondBedragHalfEven)
 


### PR DESCRIPTION
Now BigDecimals can also be rounded with "BigDecimal naarBeneden (or other rounding modes) afgerond op (Int) decimalen". Expanded property based tests.
