### PR TITLE
Patched the way AfrondingWords were integrated into the DSL.

### DIFF
--- a/engine/src/main/scala/org/scalarules/dsl/nl/ScalaRulesDsl.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/ScalaRulesDsl.scala
@@ -8,7 +8,7 @@ import org.scalarules.engine._
   * Aggregates the keywords and implicit definitions of the Scala-Rules DSL. The implicits available in this
   * trait can be used by importing the `grammar` package object's members, or extending this trait.
   */
-trait ScalaRulesDsl extends AfrondingsImplicits
+trait ScalaRulesDsl extends AfrondingsWordsTrait
   with DslConditionImplicits
   with DslEvaluationImplicits
   with DatumImplicits

--- a/engine/src/main/scala/org/scalarules/dsl/nl/grammar/AfrondingsWordsTrait.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/grammar/AfrondingsWordsTrait.scala
@@ -7,7 +7,7 @@ import org.scalarules.finance.nl.{Bedrag, Percentage}
 import scala.language.{implicitConversions, postfixOps}
 import scala.math.BigDecimal.RoundingMode.RoundingMode
 
-object AfrondingsWords {
+trait AfrondingsWordsTrait {
 
   /**
     * a "filler" value required to enforce proper Dsl readability
@@ -18,7 +18,7 @@ object AfrondingsWords {
 
     /**
       * initiates a dsl mathematical rounding sequence: half-even
- *
+      *
       * @param afgerond obligatory word-val to enable a natural language expression of rounding
       * @return AfrondingOpWord
       */
@@ -26,7 +26,7 @@ object AfrondingsWords {
 
     /**
       * initiates a dsl mathematical rounding sequence: half-down
- *
+      *
       * @param afgerond obligatory word-val to enable a natural language expression of rounding
       * @return AfrondingOpWord
       */
@@ -34,7 +34,7 @@ object AfrondingsWords {
 
     /**
       * initiates a dsl mathematical rounding sequence: floor
- *
+      *
       * @param afgerond obligatory word-val to enable a natural language expression of rounding
       * @return AfrondingOpWord
       */
@@ -42,7 +42,7 @@ object AfrondingsWords {
 
     /**
       * initiates a dsl mathematical rounding sequence: ceiling
- *
+      *
       * @param afgerond obligatory word-val to enable a natural language expression of rounding
       * @return AfrondingOpWord
       */
@@ -50,7 +50,7 @@ object AfrondingsWords {
 
     /**
       * initiates a dsl mathematical rounding sequence: down
- *
+      *
       * @param afgerond obligatory word-val to enable a natural language expression of rounding
       * @return AfrondingOpWord
       */
@@ -58,7 +58,7 @@ object AfrondingsWords {
 
     /**
       * initiates a dsl mathematical rounding sequence: half-up
- *
+      *
       * @param afgerond obligatory word-val to enable a natural language expression of rounding
       * @return AfrondingOpWord
       */
@@ -66,7 +66,7 @@ object AfrondingsWords {
 
     /**
       * initiates a dsl mathematical rounding sequence: up
- *
+      *
       * @param afgerond obligatory word-val to enable a natural language expression of rounding
       * @return AfrondingOpWord
       */
@@ -77,7 +77,7 @@ object AfrondingsWords {
 
     /**
       * allows the dsl rounding to take an integer as its parameter for the amount of digits to be rounded to
- *
+      *
       * @param aantalDecimalen integer representing the number of digits to be rounded to
       * @return Afronding
       */
@@ -89,7 +89,7 @@ object AfrondingsWords {
     /**
       * We could have ended the call with "op" (where we have all the information),
       * but for natural language purposes and later flexibility, were are enforcing "decimalen" as closing statement.
- *
+      *
       * @return DslEvaluation[Percentage]
       */
     def decimalen: DslEvaluation[T] = {
@@ -103,17 +103,11 @@ object AfrondingsWords {
   }
 
   sealed class AfgerondKeyword
-}
 
-trait Afrondbaar[T] {
-  def rondAfOp(afTeRonden: T, aantalDecimalen: Integer, afrondingsWijze: RoundingMode): T
-}
-
-trait AfrondingsImplicits {
   implicit def afrondbaarBigDecimal: Afrondbaar[BigDecimal] = {
     new Afrondbaar[BigDecimal] {
       override def rondAfOp(afTeRonden: BigDecimal, aantalDecimalen: Integer, afrondingsWijze: RoundingMode): BigDecimal =
-      afTeRonden.setScale(aantalDecimalen, afrondingsWijze)
+        afTeRonden.setScale(aantalDecimalen, afrondingsWijze)
     }
   }
 
@@ -131,4 +125,9 @@ trait AfrondingsImplicits {
     }
   }
 }
+
+trait Afrondbaar[T] {
+  def rondAfOp(afTeRonden: T, aantalDecimalen: Integer, afrondingsWijze: RoundingMode): T
+}
+
 

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsTestBerekening.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsTestBerekening.scala
@@ -1,6 +1,6 @@
 package org.scalarules.dsl.nl.grammar
 
-import org.scalarules.dsl.nl.grammar.AfrondingsWords._
+import org.scalarules.dsl.nl.grammar._
 import org.scalarules.dsl.nl.grammar.AfrondingsTestBerekeningGlossary._
 
 import scala.language.postfixOps

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsWordsTraitTest.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/AfrondingsWordsTraitTest.scala
@@ -16,7 +16,7 @@ import scala.language.postfixOps
   * This way there is a fair bit of redundancy within the tests and a lot of numbers are run through the functions so
   * if any discrepancies exist between the DSL and the corresponding BigDecimal.setScale function, we will find them.
   */
-class AfrondingsWordsTest extends PropSpec with Checkers {
+class AfrondingsWordsTraitTest extends PropSpec with Checkers {
 
   /* BigDecimal property base tests*/
   property("BigDecimal: halfNaarEven should match BigDecimal.RoundingMode.HALF_EVEN for positive doubles") {


### PR DESCRIPTION
After this change you no longer have to explicitly import AfrondingsWords._ if  you already have org.scalarules.dsl.nl.grammar._ (See #58)
