### PR TITLE
Checking and skipping outputs already in context

### DIFF
--- a/engine-core/src/main/scala/org/scalarules/engine/FactEngine.scala
+++ b/engine-core/src/main/scala/org/scalarules/engine/FactEngine.scala
@@ -128,7 +128,7 @@ object FactEngine {
     */
   def runNormalDerivations(c: Context, derivations: List[Derivation]): Context = {
     def evaluator(c: Context, d: Derivation): Context = {
-      if (d.condition(c)) {
+      if (!c.contains(d.output) && d.condition(c)) {
         val operation = d match {
           case der: SubRunDerivation => {
             val options: Seq[Option[Any]] = runSubCalculations(c, der.subRunData)
@@ -161,7 +161,9 @@ object FactEngine {
   def runDebugDerivations(c: Context, derivations: List[Derivation]): (Context, List[Step]) = {
     def evaluator(t: (Context, List[Step]), d: Derivation): (Context, List[Step]) = {
       val (c, steps) = t
-      if (d.condition(c)) {
+      if (c.contains(d.output)) {
+        (c, Step(c, d, "Output exists in context, skipping", c) :: steps)
+      } else if (d.condition(c)) {
         d match {
           case der: SubRunDerivation => {
             val (results, subSteps): (List[Context], List[List[Step]]) = runSubCalculations(c, der.subRunData, d).unzip

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/ConditionsBerekening.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/ConditionsBerekening.scala
@@ -11,4 +11,10 @@ class ConditionsBerekening extends Berekening (
   ,
   Gegeven(unavailableInput is afwezig) Bereken
     outputShouldBeAvailableIfInputIsNotAvailable is BigDecimal(12)
+  ,
+  Gegeven (altijd)
+  Bereken
+    tryToOverwriteThisValue is eerste (missingValueToUseInEerste, defaultValueForOverwriting) en
+    defaultValueForOverwriting is BigDecimal(0)
+
 )

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/ConditionsBerekeningGlossary.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/ConditionsBerekeningGlossary.scala
@@ -9,4 +9,9 @@ object ConditionsBerekeningGlossary extends Glossary {
   val outputAlwaysAvailable = defineFact[BigDecimal]
   val outputShouldBeAvailableIfInputIsAvailable = defineFact[BigDecimal]
   val outputShouldBeAvailableIfInputIsNotAvailable = defineFact[BigDecimal]
+
+  val tryToOverwriteThisValue = defineFact[BigDecimal]
+  val defaultValueForOverwriting = defineFact[BigDecimal]
+  val missingValueToUseInEerste = defineFact[BigDecimal]
+
 }

--- a/engine/src/test/scala/org/scalarules/dsl/nl/grammar/ConditionsBerekeningTest.scala
+++ b/engine/src/test/scala/org/scalarules/dsl/nl/grammar/ConditionsBerekeningTest.scala
@@ -45,4 +45,10 @@ class ConditionsBerekeningTest extends InternalBerekeningenTester(new Conditions
     outputShouldBeAvailableIfInputIsNotAvailable niet aanwezig
   )
 
+  test("of aanwezige waarde niet wordt overschreven") gegeven (
+    tryToOverwriteThisValue is BigDecimal(100)
+  ) verwacht (
+    tryToOverwriteThisValue is BigDecimal(100)
+  )
+
 }


### PR DESCRIPTION
From the beginning, we've been reasoning with the notion of being able to fixate any value in a series of derivation. If you want to skip a part of a calculation, simply set the Fact you know to a value and it will not be recomputed.

However, the engine did not actually support this... 😨  This PR actually corrects this behaviour and explicitly checks whether the current output is already set before even a condition is triggered. The debug runner also outputs this status in its trace by adding this message: `Output exists in context, skipping`.
