### PR TITLE
Business Service v1

### DIFF
--- a/engine/src/main/scala/org/scalarules/dsl/nl/grammar/BerekeningFlow.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/grammar/BerekeningFlow.scala
@@ -94,10 +94,10 @@ class LijstOpbouwConstruct[Uit](condition: DslCondition, output: Fact[List[Uit]]
 
 // --- supports naming the invoer and uitvoer inside an ElementBerekening
 class InvoerWord{
-  def is[In](iteratee: Fact[In]): InvoerSpec[In] = new InvoerSpec[In](iteratee)
+  def is[In](iteratee: Fact[In]): InvoerSpecification[In] = new InvoerSpecification[In](iteratee)
 }
 class UitvoerWord{
-  def is[Uit](iteratee: Fact[Uit]): UitvoerSpec[Uit] = new UitvoerSpec[Uit](iteratee)
+  def is[Uit](iteratee: Fact[Uit]): UitvoerSpecification[Uit] = new UitvoerSpecification[Uit](iteratee)
 }
 
 class BerekeningAccumulator private[grammar](val condition: DslCondition, val derivations: List[Derivation]) {

--- a/engine/src/main/scala/org/scalarules/dsl/nl/grammar/berekeningen.scala
+++ b/engine/src/main/scala/org/scalarules/dsl/nl/grammar/berekeningen.scala
@@ -7,8 +7,8 @@ class Berekening(berekeningAccumulators: BerekeningAccumulator*) {
   val berekeningen: List[Derivation] = berekeningAccumulators.flatMap(_.derivations).toList
 }
 
-class InvoerSpec[In](val iteratee: Fact[In])
-class UitvoerSpec[Uit](val resultee: Fact[Uit])
+class InvoerSpecification[In](val iteratee: Fact[In])
+class UitvoerSpecification[Uit](val resultee: Fact[Uit])
 
 /**
   * Een ElementBerekening is een Berekening met een enkele invoer en een enkele uitvoer parameter. Deze worden voornamelijk gebruikt bij het definieren van
@@ -16,7 +16,7 @@ class UitvoerSpec[Uit](val resultee: Fact[Uit])
   *
   * class MijnBerekening extends ElementBerekening[<invoertype>, <uitvoertype>] (
   */
-class ElementBerekening[In, Uit](invoer: InvoerSpec[In], uitvoer: UitvoerSpec[Uit], berekeningAccumulators: BerekeningAccumulator*) extends Berekening(berekeningAccumulators:_*) {
+class ElementBerekening[In, Uit](invoer: InvoerSpecification[In], uitvoer: UitvoerSpecification[Uit], berekeningAccumulators: BerekeningAccumulator*) extends Berekening(berekeningAccumulators:_*) {
   def invoerFact: Fact[In] = invoer.iteratee
   def uitvoerFact: Fact[Uit] = uitvoer.resultee
 }
@@ -24,4 +24,3 @@ class ElementBerekening[In, Uit](invoer: InvoerSpec[In], uitvoer: UitvoerSpec[Ui
 trait ElementBerekeningReference[In, Uit] {
   def berekening: ElementBerekening[In, Uit]
 }
-

--- a/engine/src/main/scala/org/scalarules/service/dsl/BusinessService.scala
+++ b/engine/src/main/scala/org/scalarules/service/dsl/BusinessService.scala
@@ -1,0 +1,95 @@
+package org.scalarules.service.dsl
+
+import org.scalarules.derivations.Derivation
+import org.scalarules.dsl.nl.grammar.Berekening
+import org.scalarules.facts.Fact
+import org.scalarules.utils.Glossary
+import org.scalarules.engine._
+
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Een BusinessService stelt de gebruiker in staat om te specificeren (en te ontsluiten):
+  * - dat bepaalde berekeningen bij elkaar gegroepeerd zijn (dit wordt afgedwongen),
+  * - dat sommige invoerfeiten verplicht zijn om te vullen (dit wordt afgedwongen),
+  * - welke defaults er gelden voor niet-verplichte invoer,
+  * - welke feiten specifiek dienen als uitvoer: de "resultaten" van de berekening,
+  * - welke feiten Uberhaupt beschikbaar worden gesteld aan de buitenwereld (glossaries).
+  *
+  * Iedere BusinessService heeft een run-methode die afdwingt dat er eerst gevalideerd wordt of alle verplichte invoer aanwezig is.
+  */
+case class BusinessService(berekeningen: List[Berekening],
+                      glossaries: List[Glossary],
+                      verplichteInvoerFacts: List[Fact[Any]],
+                      optioneleInvoerFacts: Map[Fact[Any], Any],
+                      uitvoerFacts: List[Fact[Any]]) {
+
+  type ErrorMessage = String
+
+  val optioneleInvoerFactsList: List[Fact[Any]] = optioneleInvoerFacts.keys.toList
+
+  def validate(inputContext: Context): List[ErrorMessage] =
+    validateSpecifications ::: validateInvoer(inputContext)
+
+  def validateSpecifications: List[ErrorMessage] =
+    validateBerekeningen ::: validateGlossaries ::: validateAllFactsInGlossary ::: validateNoFactsBothOptionalAndMandatoryInvoer ::: validateUitvoer
+
+  def validateBerekeningen: List[ErrorMessage] = berekeningen match {
+    case Nil => List("no Berekeningen specified!")
+    case list: List[Berekening] => validateNoRedundancies(list)
+  }
+
+  private def validateNoRedundancies(list: List[Any]) =
+    list.map(_.getClass)
+      .groupBy(identity)
+      .collect{
+        case (berekening, occurrences) if occurrences.length > 1 => berekening.toString + " was specified more than once!"
+      }.toList
+
+  def validateGlossaries() : List[ErrorMessage] = glossaries match {
+    case Nil => List("no Glossaries specified!")
+    case list: List[Glossary] => validateNoRedundancies(list)
+  }
+
+  def validateAllFactsInGlossary() : List[ErrorMessage] = {
+    val factsInScope: List[Fact[Any]] = glossaries.foldLeft(List():List[Fact[Any]])((a: List[Fact[Any]], b: Glossary) => a ++ b.facts.values)
+    val definedBusinessServiceFacts: List[Fact[Any]] = optioneleInvoerFactsList ::: verplichteInvoerFacts ::: uitvoerFacts
+
+    definedBusinessServiceFacts.filterNot(factsInScope.contains(_)).map(
+      notFound => s"$notFound specified, but not found in specified glossaries so not in scope!")
+  }
+
+  def validateNoFactsBothOptionalAndMandatoryInvoer(): List[ErrorMessage] =
+    verplichteInvoerFacts.intersect(optioneleInvoerFactsList).map(
+      doubleFact => s"$doubleFact specified as both verplichteInvoer and optioneleInvoer")
+
+  def validateInvoer(inputContext: Context): List[ErrorMessage] = verplichteInvoerFacts match {
+    case Nil => List("no verplichteInvoer specified, but this is mandatory!")
+    case list: List[Fact[Any]] => list.collect { case fact: Fact[Any] if !inputContext.contains(fact) => s"$fact not provided in context, but mandatory!"}
+  }
+
+  def validateUitvoer(): List[ErrorMessage] = uitvoerFacts match {
+    case Nil => List("no uitvoerFacts specified, but this is mandatory!")
+    case _ => Nil
+  }
+
+  def run(inputContext: Context, runFunction: (Context, List[Derivation]) => Context): Try[Context] =
+    validate(inputContext) match {
+      case Nil => Success(runFunction(optioneleInvoerFacts ++ inputContext, berekeningen.flatMap(_.berekeningen)))
+      case list: List[ErrorMessage] => Failure(
+        new IllegalStateException(list.reduceLeft((a: ErrorMessage, b: ErrorMessage) => a + " / " + b))
+      )
+    }
+
+  def runDebug(inputContext: Context, runFunction: (Context, List[Derivation]) => (Context, List[Step])): Try[(Context, List[Step])] =
+    validate(inputContext) match {
+      case Nil => Success(runFunction(optioneleInvoerFacts ++ inputContext, berekeningen.flatMap(_.berekeningen)))
+      case list: List[ErrorMessage] => Failure(
+        new IllegalStateException(list.reduceLeft((a: ErrorMessage, b: ErrorMessage) => a + " / " + b))
+      )
+    }
+}
+
+object BusinessServiceHelper {
+  val Geen = Map.empty[Fact[Any], String]
+}

--- a/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTest.scala
+++ b/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTest.scala
@@ -8,7 +8,7 @@ import org.scalarules.service.dsl.BusinessServiceTestGlossary3._
 import org.scalarules.service.dsl.NotABusinessServiceTestGlossary1._
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 
 class BusinessServiceTest extends FlatSpec with Matchers {
@@ -60,34 +60,38 @@ class BusinessServiceTest extends FlatSpec with Matchers {
   }
 
   it should "perform the proper derivations when given proper input" in {
-    val result: Context = new TestBusinessServiceAlles().run(Map(
+    new TestBusinessServiceAlles().run(Map(
       verplichteInvoer1 -> BigDecimal(1).euro,
       verplichteInvoer2 -> BigDecimal(2).euro,
       verplichteInvoer3 -> BigDecimal(3).euro
-    ), FactEngine.runNormalDerivations).get
-
-    result(uitvoer1) should be ((1 + 1).euro)
-    result(uitvoer2) should be ((2 + 2).euro)
-    result(uitvoer3) should be ((3 + 3).euro)
+    ), FactEngine.runNormalDerivations) match {
+      case Failure(f) => f.getMessage shouldBe "Something is likely wrong in the test setup if this test fails because of validation or run errors"
+      case Success(s) =>
+        s(uitvoer1) should be ((1 + 1).euro)
+        s(uitvoer2) should be ((2 + 2).euro)
+        s(uitvoer3) should be ((3 + 3).euro)
+    }
   }
 
   it should "overwrite optional invoer when given proper input" in {
-    val result: Context = new TestBusinessServiceAlles().run(Map(
+    new TestBusinessServiceAlles().run(Map(
       verplichteInvoer1 -> 1.euro,
       verplichteInvoer2 -> 2.euro,
       verplichteInvoer3 -> 3.euro,
       optioneleInvoer1 -> 11.euro,
       optioneleInvoer2 -> 22.euro,
       optioneleInvoer3 -> 33.euro
-    ), FactEngine.runNormalDerivations).get
-
-    result(uitvoer1) should be ((1 + 11).euro)
-    result(uitvoer2) should be ((2 + 22).euro)
-    result(uitvoer3) should be ((3 + 33).euro)
+    ), FactEngine.runNormalDerivations) match {
+      case Failure(f) => f.getMessage shouldBe "Something is likely wrong in the test setup if this test fails because of validation or run errors"
+      case Success(s) =>
+        s(uitvoer1) should be((1 + 11).euro)
+        s(uitvoer2) should be((2 + 22).euro)
+        s(uitvoer3) should be((3 + 33).euro)
+    }
   }
 
   it should "have no trouble with the absence of optionalInvoer specifications" in {
-    val result: Context = new TestBusinessServiceGeenOptioneel().run(Map(
+    new TestBusinessServiceGeenOptioneel().run(Map(
       verplichteInvoer1 -> 1.euro,
       verplichteInvoer2 -> 2.euro,
       verplichteInvoer3 -> 3.euro,
@@ -95,11 +99,13 @@ class BusinessServiceTest extends FlatSpec with Matchers {
       optioneleInvoer1 -> 11.euro,
       optioneleInvoer2 -> 22.euro,
       optioneleInvoer3 -> 33.euro
-    ), FactEngine.runNormalDerivations).get
-
-    result(uitvoer1) should be ((1 + 11).euro)
-    result(uitvoer2) should be ((2 + 22).euro)
-    result(uitvoer3) should be ((3 + 33).euro)
+    ), FactEngine.runNormalDerivations) match {
+      case Failure(f) => f.getMessage shouldBe "Something is likely wrong in the test setup if this test fails because of validation or run errors"
+      case Success(s) =>
+        s(uitvoer1) should be((1 + 11).euro)
+        s(uitvoer2) should be((2 + 22).euro)
+        s(uitvoer3) should be((3 + 33).euro)
+    }
   }
 
   behavior of "throw errors when improperly specified"

--- a/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTest.scala
+++ b/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTest.scala
@@ -1,0 +1,251 @@
+package org.scalarules.service.dsl
+
+import org.scalarules.engine.{Context, FactEngine}
+import org.scalarules.finance.nl._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary1._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary2._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary3._
+import org.scalarules.service.dsl.NotABusinessServiceTestGlossary1._
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Try
+
+
+class BusinessServiceTest extends FlatSpec with Matchers {
+  behavior of "provide insight into specifications"
+
+  it should "provide insight into what berekeningen are part of the service" in {
+    val businessService: BusinessService = new TestBusinessServiceAlles()
+
+    businessService.berekeningen.map(_.getClass) should be (
+      List(new BusinessServiceTestBerekening1, new BusinessServiceTestBerekening2, new BusinessServiceTestBerekening3).map(_.getClass))
+  }
+
+  it should "provide insight into what glossaries are part of the service" in {
+    val businessService: BusinessService = new TestBusinessServiceAlles()
+
+    businessService.glossaries should be (List(BusinessServiceTestGlossary1, BusinessServiceTestGlossary2, BusinessServiceTestGlossary3))
+  }
+
+  it should "provide insight into what is verplichte invoer" in {
+    val businessService: BusinessService = new TestBusinessServiceAlles()
+
+    businessService.verplichteInvoerFacts should be (List(verplichteInvoer1, verplichteInvoer2, verplichteInvoer3))
+  }
+
+  it should "provide insight into what is optionele invoer" in {
+    val businessService: BusinessService = new TestBusinessServiceAlles()
+
+    businessService.optioneleInvoerFactsList should be (List(optioneleInvoer1, optioneleInvoer2, optioneleInvoer3))
+  }
+
+  it should "provide insight into what is uitvoer" in {
+    val businessService: BusinessService = new TestBusinessServiceAlles()
+
+    businessService.uitvoerFacts should be (List(uitvoer1, uitvoer2, uitvoer3))
+  }
+
+
+
+  behavior of "throw no errors when used as intended"
+
+  it should "perform succesful derivations when given proper input" in {
+    val result: Try[Context] = new TestBusinessServiceAlles().run(Map(
+      verplichteInvoer1 -> BigDecimal(1).euro,
+      verplichteInvoer2 -> BigDecimal(2).euro,
+      verplichteInvoer3 -> BigDecimal(3).euro
+    ), FactEngine.runNormalDerivations)
+
+    result.isSuccess
+  }
+
+  it should "perform the proper derivations when given proper input" in {
+    val result: Context = new TestBusinessServiceAlles().run(Map(
+      verplichteInvoer1 -> BigDecimal(1).euro,
+      verplichteInvoer2 -> BigDecimal(2).euro,
+      verplichteInvoer3 -> BigDecimal(3).euro
+    ), FactEngine.runNormalDerivations).get
+
+    result(uitvoer1) should be ((1 + 1).euro)
+    result(uitvoer2) should be ((2 + 2).euro)
+    result(uitvoer3) should be ((3 + 3).euro)
+  }
+
+  it should "overwrite optional invoer when given proper input" in {
+    val result: Context = new TestBusinessServiceAlles().run(Map(
+      verplichteInvoer1 -> 1.euro,
+      verplichteInvoer2 -> 2.euro,
+      verplichteInvoer3 -> 3.euro,
+      optioneleInvoer1 -> 11.euro,
+      optioneleInvoer2 -> 22.euro,
+      optioneleInvoer3 -> 33.euro
+    ), FactEngine.runNormalDerivations).get
+
+    result(uitvoer1) should be ((1 + 11).euro)
+    result(uitvoer2) should be ((2 + 22).euro)
+    result(uitvoer3) should be ((3 + 33).euro)
+  }
+
+  it should "have no trouble with the absence of optionalInvoer specifications" in {
+    val result: Context = new TestBusinessServiceGeenOptioneel().run(Map(
+      verplichteInvoer1 -> 1.euro,
+      verplichteInvoer2 -> 2.euro,
+      verplichteInvoer3 -> 3.euro,
+      //geen optionalInvoer specified, but the facts are still required by the underlying derivations!
+      optioneleInvoer1 -> 11.euro,
+      optioneleInvoer2 -> 22.euro,
+      optioneleInvoer3 -> 33.euro
+    ), FactEngine.runNormalDerivations).get
+
+    result(uitvoer1) should be ((1 + 11).euro)
+    result(uitvoer2) should be ((2 + 22).euro)
+    result(uitvoer3) should be ((3 + 33).euro)
+  }
+
+  behavior of "throw errors when improperly specified"
+
+  it should "fail with a clear message when no berekeningen are specified" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceGeenBerekeningen().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("no Berekeningen specified!")
+  }
+
+  it should "fail with a clear message when any berekeningen are specified more than once" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceRedundantlySpecifiedBerekeningen().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("class org.scalarules.service.dsl.BusinessServiceTestBerekening1 was specified more than once!")
+  }
+
+  it should "fail with a clear message when no Glossary provided" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceGeenGlossaries().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        notABusinessServiceVerplichtFact -> 6.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage.contains("no Glossaries specified!") should be (true)
+  }
+
+  it should "fail with a clear message when no verplichteInvoer specified" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceGeenVerplichteInvoer().run(Map(
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("no verplichteInvoer specified, but this is mandatory!")
+  }
+
+  it should "fail with a clear message when no uitvoer specified" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceGeenUitvoer().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("no uitvoerFacts specified, but this is mandatory!")
+  }
+
+  it should "fail with a clear message when verplichteInvoer is specified but not in provided Glossaries" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceIllegaalFactVerplicht().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        notABusinessServiceVerplichtFact -> 6.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("notABusinessServiceVerplichtFact specified, but not found in specified glossaries so not in scope!")
+  }
+
+  it should "fail with a clear message when optioneleInvoer is specified but not in provided Glossaries" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceIllegaalFactOptioneel().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        notABusinessServiceOptioneelFact -> 6.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("notABusinessServiceOptioneelFact specified, but not found in specified glossaries so not in scope!")
+  }
+
+it should "fail with a clear message when uitvoer is specified but not in provided Glossaries" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceIllegaalFactUitvoer().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("notABusinessServiceUitvoer specified, but not found in specified glossaries so not in scope!")
+  }
+
+it should "fail with a clear message when a fact is is specified as verplichteInvoer en optioneleInvoer" in {
+    val exception = intercept[IllegalStateException] {
+      val result: Try[Context] = new TestBusinessServiceFactAsBothVerplichtAndOptioneel().run(Map(
+        verplichteInvoer1 -> 1.euro,
+        verplichteInvoer2 -> 2.euro,
+        verplichteInvoer3 -> 3.euro,
+        optioneleInvoer1 -> 11.euro,
+        optioneleInvoer2 -> 22.euro,
+        optioneleInvoer3 -> 33.euro
+      ), FactEngine.runNormalDerivations)
+
+      result.get
+    }
+    exception.getMessage should be ("verplichteInvoer1 specified as both verplichteInvoer and optioneleInvoer")
+  }
+
+}

--- a/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTestBerekeningen.scala
+++ b/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTestBerekeningen.scala
@@ -1,0 +1,37 @@
+package org.scalarules.service.dsl
+
+import org.scalarules.dsl.nl.grammar._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary1._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary2._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary3._
+import org.scalarules.service.dsl.NotABusinessServiceTestGlossary1._
+import scala.language.postfixOps
+
+
+class BusinessServiceTestBerekening1 extends Berekening (
+
+  Gegeven(altijd) Bereken
+    uitvoer1 is (verplichteInvoer1 + optioneleInvoer1)
+
+)
+
+class BusinessServiceTestBerekening2 extends Berekening (
+
+  Gegeven(altijd) Bereken
+    uitvoer2 is (verplichteInvoer2 + optioneleInvoer2)
+
+)
+
+class BusinessServiceTestBerekening3 extends Berekening (
+
+  Gegeven(altijd) Bereken
+    uitvoer3 is (verplichteInvoer3 + optioneleInvoer3)
+
+)
+
+class NotABusinessServiceTestBerekening1 extends Berekening (
+
+  Gegeven(altijd) Bereken
+    notABusinessServiceUitvoer is (notABusinessServiceVerplichtFact + notABusinessServiceOptioneelFact)
+
+)

--- a/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTestGlossaries.scala
+++ b/engine/src/test/scala/org/scalarules/service/dsl/BusinessServiceTestGlossaries.scala
@@ -1,0 +1,28 @@
+package org.scalarules.service.dsl
+
+import org.scalarules.finance.nl.Bedrag
+import org.scalarules.utils.Glossary
+
+object BusinessServiceTestGlossary1 extends Glossary {
+  val verplichteInvoer1 = defineFact[Bedrag]
+  val optioneleInvoer1 = defineFact[Bedrag]
+  val uitvoer1 = defineFact[Bedrag]
+}
+
+object BusinessServiceTestGlossary2 extends Glossary {
+  val verplichteInvoer2 = defineFact[Bedrag]
+  val optioneleInvoer2 = defineFact[Bedrag]
+  val uitvoer2 = defineFact[Bedrag]
+}
+
+object BusinessServiceTestGlossary3 extends Glossary {
+  val verplichteInvoer3 = defineFact[Bedrag]
+  val optioneleInvoer3 = defineFact[Bedrag]
+  val uitvoer3 = defineFact[Bedrag]
+}
+
+object NotABusinessServiceTestGlossary1 extends Glossary {
+  val notABusinessServiceVerplichtFact = defineFact[Bedrag]
+  val notABusinessServiceOptioneelFact = defineFact[Bedrag]
+  val notABusinessServiceUitvoer = defineFact[Bedrag]
+}

--- a/engine/src/test/scala/org/scalarules/service/dsl/TestBusinessServices.scala
+++ b/engine/src/test/scala/org/scalarules/service/dsl/TestBusinessServices.scala
@@ -1,0 +1,354 @@
+package org.scalarules.service.dsl
+
+import org.scalarules.finance.nl._
+import org.scalarules.service.dsl.BusinessServiceHelper._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary1._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary2._
+import org.scalarules.service.dsl.BusinessServiceTestGlossary3._
+import org.scalarules.service.dsl.NotABusinessServiceTestGlossary1._
+
+class TestBusinessServiceAlles extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1.euro,
+    optioneleInvoer2 -> 2.euro,
+    optioneleInvoer3 -> 3.euro
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3
+  )
+)
+
+class TestBusinessServiceIllegaalFactVerplicht extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    notABusinessServiceVerplichtFact
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1.euro
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1
+  )
+)
+
+class TestBusinessServiceIllegaalFactOptioneel extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1.euro,
+    notABusinessServiceOptioneelFact -> 42.euro
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1
+  )
+)
+
+class TestBusinessServiceIllegaalFactUitvoer extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    notABusinessServiceUitvoer
+  )
+)
+
+class TestBusinessServiceGeenBerekeningen extends BusinessService (
+  berekeningen = Nil,
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1,
+    optioneleInvoer2 -> 2,
+    optioneleInvoer3 -> 3
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3
+  )
+)
+
+class TestBusinessServiceGeenGlossaries extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = Nil,
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1,
+    optioneleInvoer2 -> 2,
+    optioneleInvoer3 -> 3
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3
+  )
+)
+
+class TestBusinessServiceGeenVerplichteInvoer extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3
+  ),
+
+  verplichteInvoerFacts = Nil,
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1,
+    optioneleInvoer2 -> 2,
+    optioneleInvoer3 -> 3
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3
+  )
+)
+
+class TestBusinessServiceGeenOptioneel extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3,
+    optioneleInvoer1,
+    optioneleInvoer2,
+    optioneleInvoer3
+  ),
+
+  optioneleInvoerFacts = Geen,
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3
+  )
+)
+
+class TestBusinessServiceGeenUitvoer extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1,
+    optioneleInvoer2 -> 2,
+    optioneleInvoer3 -> 3
+  ),
+
+  uitvoerFacts = Nil
+)
+
+class TestBusinessServiceOnlySpecifiedBerekeningen extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3,
+    NotABusinessServiceTestGlossary1
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3,
+    notABusinessServiceVerplichtFact
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1,
+    optioneleInvoer2 -> 2,
+    optioneleInvoer3 -> 3,
+    notABusinessServiceOptioneelFact -> 42
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3,
+    notABusinessServiceUitvoer
+  )
+)
+
+class TestBusinessServiceRedundantlySpecifiedBerekeningen extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3
+  ),
+
+  optioneleInvoerFacts = Map(
+    optioneleInvoer1 -> 1,
+    optioneleInvoer2 -> 2,
+    optioneleInvoer3 -> 3
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3
+  )
+)
+
+class TestBusinessServiceFactAsBothVerplichtAndOptioneel extends BusinessService (
+  berekeningen = List(
+    new BusinessServiceTestBerekening1,
+    new BusinessServiceTestBerekening2,
+    new BusinessServiceTestBerekening3
+  ),
+
+  glossaries = List(
+    BusinessServiceTestGlossary1,
+    BusinessServiceTestGlossary2,
+    BusinessServiceTestGlossary3
+  ),
+
+  verplichteInvoerFacts = List(
+    verplichteInvoer1,
+    verplichteInvoer2,
+    verplichteInvoer3
+  ),
+
+  optioneleInvoerFacts = Map(
+    verplichteInvoer1 -> 1,
+    optioneleInvoer1 -> 1,
+    optioneleInvoer2 -> 2,
+    optioneleInvoer3 -> 3
+  ),
+
+  uitvoerFacts = List(
+    uitvoer1,
+    uitvoer2,
+    uitvoer3
+  )
+)


### PR DESCRIPTION
First version of the BusinessService

Allows you to specify which groups of Berekeningen belong together and are "in scope" for deriving facts.
Allows you to specify which Glossaries are "in scope" (so the user is not burdened with facts that are not relevant).
Allows you to demand certain facts are filled as input (verplichteInvoer).
Allows you to provide defaults for optional facts (optioneleInvoer).
Allows you to declare the important result facts (uitvoer) to better illustrate the purpose of Berekeningen.

Fixes #82